### PR TITLE
[BB-590] fix client `ListOnCallUsers` schedule id param

### DIFF
--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -411,12 +410,12 @@ func (c *Client) ListOnCallUsers(
 	scheduleID string,
 ) ([]int, error) {
 	logger := ctxzap.Extract(ctx)
-	now := time.Now()
+	now := time.Now().UTC()
 	parsedURL := c.generateURL(ListScheduleShiftsAPIEndpoint, map[string]string{
-		"include":      "user",
-		"schedule_ids": fmt.Sprintf(`[%s]`, scheduleID),
-		"from":         now.Format(time.RFC3339),
-		"to":           now.Add(1 * time.Hour).Format(time.RFC3339),
+		"include":        "user",
+		"schedule_ids[]": scheduleID,
+		"from":           now.Format(time.RFC3339),
+		"to":             now.Add(1 * time.Hour).Format(time.RFC3339),
 	}, scheduleID)
 	logger.Debug("Generated URL", zap.String("parsedURL", parsedURL.String()))
 


### PR DESCRIPTION
#### Description
The rootly api for `/v1/shifts` expects the schedule ids query param to be `&schedule_ids[]=your-schedule-id` not `&schedule_ids=[your-schedule-id]`. This change updates the rootly client to former. Unfortunately with the latter format rootly returns shifts for all schedules, instead of responding back with no matches or an error.

Before:
![Screenshot 2025-04-28 at 14 53 06](https://github.com/user-attachments/assets/20dbf947-1948-4956-acd3-d69db161c100)

After:
![Screenshot 2025-04-28 at 14 53 41](https://github.com/user-attachments/assets/60fa4525-bcf0-46a9-bfe6-0c69ed2e745d)
