### PR TITLE
uhttp client with logger

### DIFF
--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -37,7 +37,11 @@ type Client struct {
 
 // NewClient creates a new Rootly client. Allows for a configurable base URL, API key, and resources page size.
 func NewClient(ctx context.Context, baseURL string, apiKey string, resourcesPageSize int) (*Client, error) {
-	httpClient, err := uhttp.NewBaseHttpClientWithContext(ctx, http.DefaultClient)
+	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP client failed: %w", err)
+	}
+	wrapper, err := uhttp.NewBaseHttpClientWithContext(ctx, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +64,7 @@ func NewClient(ctx context.Context, baseURL string, apiKey string, resourcesPage
 	// as it provides automatic rate limiting handling, error wrapping with gRPC status codes,
 	// and built-in GET response caching
 	return &Client{
-		httpClient:        httpClient,
+		httpClient:        wrapper,
 		baseURL:           parsedURL,
 		apiKey:            apiKey,
 		resourcesPageSize: resourcesPageSize,

--- a/pkg/connector/client/client_test.go
+++ b/pkg/connector/client/client_test.go
@@ -940,7 +940,7 @@ func TestClient_generateCurrentPaginatedURL(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := client.generateCurrentPaginatedURL(ctx, tc.args.pToken, tc.args.path, tc.args.pathParameters...)
+			got, err := client.generateCurrentPaginatedURL(tc.args.pToken, tc.args.path, tc.args.pathParameters...)
 			// only get an error if the provided path in unparseable, not an interesting test case
 			require.Nil(t, err)
 			require.Equal(t, tc.want, got)


### PR DESCRIPTION
#### Description

passing the logger as a field on the client fixes the lamdba outputs, but needs further investigation. are we not passing ctx properly in the sdk?

<img width="1294" height="374" alt="Screenshot 2025-07-25 at 22 15 54" src="https://github.com/user-attachments/assets/e938019d-7b60-4969-8ad8-af34c46a3811" />


#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
