### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Rootly connector
 og:title: Set up a Rootly connector - C1 docs
-og:description: Integrate your Rootly instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for Rootly. Integrate your Rootly instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for Rootly. Integrate your Rootly instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for Rootly. Integrate your Rootly instance with C1 for unified visibility and governance over user access."
 sidebarTitle: Rootly
 ---
 
@@ -74,7 +74,7 @@ Carefully copy and save the new API key.
 </Steps>
 
 Note that if you ever edit a Rootly role used on an API key, the existing key will not receive changes to the role permissions. You must generate a new API key. 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Rootly connector
 <Warning>
@@ -122,7 +122,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Rootly connector is now pulling access data into C1.
+**Done.** Your Rootly connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Rootly connector, hosted and run in your own environment.**
@@ -236,7 +236,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Rootly connector to. Rootly data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your Rootly connector is now pulling access data into C1.
+**Done.** Your Rootly connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines