### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -216,7 +216,7 @@ spec:
     spec:
       containers:
       - name: baton-rootly
-        image: ghcr.io/conductorone/baton-rootly:latest
+        image: public.ecr.aws/conductorone/baton-rootly:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -239,4 +239,3 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 **Done.** Your Rootly connector is now pulling access data into C1.
 </Tab>
 </Tabs>
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._